### PR TITLE
Fix rotary encoder DT pin and clean up

### DIFF
--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -154,6 +154,30 @@ def discover_chromecast(button):
 
 
 ##########################
+### Encoder Interrupt
+##########################
+
+_encoder_counter = 50
+_encoder_last_clk = 0
+
+def encoder_callback(channel):
+    global _encoder_counter, _encoder_last_clk
+    clk_state = GPIO.input(CLK)
+    dt_state  = GPIO.input(DT)
+    if clk_state != _encoder_last_clk:
+        old_val = _encoder_counter
+        if dt_state == clk_state and _encoder_counter < 100:
+            _encoder_counter += INCREMENT
+        elif _encoder_counter > 0:
+            _encoder_counter -= INCREMENT
+        if _encoder_counter != old_val:
+            log.info("Encoder: clk=%s dt=%s counter %d->%d", clk_state, dt_state, old_val, _encoder_counter)
+    _encoder_last_clk = clk_state
+
+GPIO.add_event_detect(CLK, GPIO.BOTH, callback=encoder_callback, bouncetime=1)
+
+
+##########################
 ### Cast and Monitor
 ##########################
 
@@ -199,10 +223,11 @@ def cast_and_monitor(start_button):
 
             log.info("Streaming: %s", mc.status.player_state)
 
-            # Volume control state
+            # Volume control state — counter managed by interrupt callback
+            global _encoder_counter
+            _encoder_counter = INITIAL_VOLUME
             counter = INITIAL_VOLUME
             prior_volume = INITIAL_VOLUME
-            clk_last_state = GPIO.input(CLK)
             pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
             last_volume_set = time.time()
 
@@ -212,19 +237,10 @@ def cast_and_monitor(start_button):
 
             # Main playback loop
             while mc.status.player_state in ("PLAYING", "BUFFERING"):
-                # Rotary encoder volume tracking
-                clk_state = GPIO.input(CLK)
-                dt_state  = GPIO.input(DT)
-                if clk_state != clk_last_state:
-                    old_counter = counter
-                    if dt_state == clk_state and counter < 100:
-                        counter += INCREMENT
-                    elif counter > 0:
-                        counter -= INCREMENT
-                    if counter != old_counter:
-                        log.info("Encoder: clk=%s dt=%s counter %d->%d", clk_state, dt_state, old_counter, counter)
+                # Read counter updated by interrupt callback
+                counter = _encoder_counter
+                if counter != prior_volume:
                     pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
-                clk_last_state = clk_state
 
                 # Time-based volume updates to Chromecast
                 now = time.time()

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -216,16 +216,20 @@ def cast_and_monitor(start_button):
                 clk_state = GPIO.input(CLK)
                 dt_state  = GPIO.input(DT)
                 if clk_state != clk_last_state:
+                    old_counter = counter
                     if dt_state == clk_state and counter < 100:
                         counter += INCREMENT
                     elif counter > 0:
                         counter -= INCREMENT
+                    if counter != old_counter:
+                        log.info("Encoder: clk=%s dt=%s counter %d->%d", clk_state, dt_state, old_counter, counter)
                     pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
                 clk_last_state = clk_state
 
                 # Time-based volume updates to Chromecast
                 now = time.time()
                 if now - last_volume_set >= VOLUME_SET_INTERVAL and prior_volume != counter:
+                    log.info("Setting volume: %d -> %d", prior_volume, counter)
                     cast.set_volume(counter / 100)
                     prior_volume = counter
                     last_volume_set = now

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -217,10 +217,11 @@ def cast_and_monitor(start_button):
                 # Rotary encoder volume tracking
                 clk_state = GPIO.input(CLK)
                 dt_state  = GPIO.input(DT)
-                if clk_state != clk_last_state and clk_state == 1 and (time.time() - last_encoder_time) > ENCODER_DEBOUNCE:
-                    if dt_state != clk_state and counter < 100:
+                if clk_state != clk_last_state and (time.time() - last_encoder_time) > ENCODER_DEBOUNCE:
+                    clockwise = (clk_state == 1 and dt_state == 0) or (clk_state == 0 and dt_state == 1)
+                    if clockwise and counter < 100:
                         counter += INCREMENT
-                    elif dt_state == clk_state and counter > 0:
+                    elif not clockwise and counter > 0:
                         counter -= INCREMENT
                     pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
                     last_encoder_time = time.time()

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -165,13 +165,10 @@ def encoder_callback(channel):
     clk_state = GPIO.input(CLK)
     dt_state  = GPIO.input(DT)
     if clk_state != _encoder_last_clk:
-        old_val = _encoder_counter
         if dt_state == clk_state and _encoder_counter < 100:
             _encoder_counter += INCREMENT
         elif _encoder_counter > 0:
             _encoder_counter -= INCREMENT
-        if _encoder_counter != old_val:
-            log.info("Encoder: clk=%s dt=%s counter %d->%d", clk_state, dt_state, old_val, _encoder_counter)
     _encoder_last_clk = clk_state
 
 GPIO.add_event_detect(CLK, GPIO.BOTH, callback=encoder_callback, bouncetime=1)

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -1,218 +1,293 @@
 import RPi.GPIO as GPIO
-import sys
 import pychromecast
 import time
-import datetime
+import logging
+import os
+import re
+import socket
+from urllib.parse import urlparse, urlunparse
 
-print(datetime.datetime.now())
-print("Beginning Execution of Cast My Vinyl")
+from config import (
+    AUDIO_STREAM, AUDIO_TYPE, TARGETS,
+    BUTTONS, LIGHTS, STATUS_LIGHT, CLK, DT, VOLTMETER,
+    VOLT_METER_SCALE, INCREMENT, INITIAL_VOLUME,
+    VOLUME_SET_INTERVAL, CONNECTION_TIMEOUT,
+    DISCOVERY_RETRIES, DISCOVERY_RETRY_DELAY,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s: %(message)s",
+)
+log = logging.getLogger(__name__)
+
+log.info("Beginning Execution of Cast My Vinyl")
 
 
 ##########################
-### Define Chromecast Targets
-#########################
-
-#Here, There, Everywhere
-targets=["Downstairs Speakers","Upstairs Speakers","All Devices"]
-#targets[0]="Downstairs Speakers"
-#targets[1]="Upstairs Speakers"
-#targets[2]="All Devices"
-audiostream="http://192.168.86.32:8000/mystream.mp3"
-
-##########################
-### Setup GPIO and naming of buttons and lights
+### IP Self-Check
 ##########################
 
-buttons=[22,27,17]
-#buttons[0]=22
-#buttons[1]=27
-#buttons[2]=17
+def get_local_ip():
+    """
+    Detect the Pi's current local IP by opening a UDP socket toward an
+    external address (no packets are actually sent).
+    Returns the IP string, or None on failure.
+    """
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception as e:
+        log.warning("Could not detect local IP: %s", e)
+        return None
 
-lights=[25,24,23]
-#lights[0]=25
-#lights[1]=24
-#lights[2]=23
-statuslight=16
 
-clk=19
-dt=26
-voltmeter=21
+def sync_stream_ip():
+    """
+    Check whether the IP in AUDIO_STREAM matches the Pi's current IP.
+    If not, rewrite the AUDIO_STREAM line in config.py and return the
+    corrected URL so the running process uses the right address.
+    """
+    current_ip = get_local_ip()
+    if current_ip is None:
+        log.warning("Skipping IP sync — could not determine local IP")
+        return AUDIO_STREAM
+
+    parsed = urlparse(AUDIO_STREAM)
+    config_ip = parsed.hostname
+
+    if current_ip == config_ip:
+        log.info("Stream IP is current (%s)", current_ip)
+        return AUDIO_STREAM
+
+    # Build the corrected URL (preserve port and path)
+    new_netloc = current_ip if parsed.port is None else f"{current_ip}:{parsed.port}"
+    new_url = urlunparse(parsed._replace(netloc=new_netloc))
+
+    # Rewrite the AUDIO_STREAM line in config.py
+    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.py")
+    try:
+        with open(config_path, "r") as f:
+            content = f.read()
+        new_content = re.sub(
+            r'^(AUDIO_STREAM\s*=\s*["\']).*?(["\'])',
+            lambda m: f"{m.group(1)}{new_url}{m.group(2)}",
+            content,
+            flags=re.MULTILINE,
+        )
+        with open(config_path, "w") as f:
+            f.write(new_content)
+        log.info("Stream IP updated in config.py: %s -> %s", config_ip, current_ip)
+    except Exception as e:
+        log.error("Failed to update config.py with new IP: %s", e)
+
+    return new_url
+
+
+AUDIO_STREAM = sync_stream_ip()
+
+
+##########################
+### GPIO Setup
+##########################
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 
-GPIO.setup(voltmeter,GPIO.OUT)
-GPIO.setup(clk,GPIO.IN,pull_up_down=GPIO.PUD_DOWN)
-GPIO.setup(dt,GPIO.IN,pull_up_down=GPIO.PUD_DOWN)
+# Rotary encoder inputs
+GPIO.setup(CLK, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+GPIO.setup(DT,  GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
 
-GPIO.setup(statuslight,GPIO.OUT)
-GPIO.setup(lights[0],GPIO.OUT)
-GPIO.setup(lights[1],GPIO.OUT)
-GPIO.setup(lights[2],GPIO.OUT)
+# Status and button indicator outputs
+GPIO.setup(STATUS_LIGHT, GPIO.OUT)
+GPIO.output(STATUS_LIGHT, False)
 
-GPIO.setup(buttons[0],GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.setup(buttons[1],GPIO.IN, pull_up_down=GPIO.PUD_UP)
-GPIO.setup(buttons[2],GPIO.IN, pull_up_down=GPIO.PUD_UP)
+for pin in LIGHTS:
+    GPIO.setup(pin, GPIO.OUT)
+    GPIO.output(pin, False)
 
-GPIO.output(statuslight,False)
-GPIO.output(lights[0],False)
-GPIO.output(lights[1],False)
-GPIO.output(lights[2],False)
+# Button inputs
+for pin in BUTTONS:
+    GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
-#initialize PWM and cycle to show startup
-pwm = GPIO.PWM(voltmeter,100)
+# Voltmeter needle (PWM output)
+GPIO.setup(VOLTMETER, GPIO.OUT)
+pwm = GPIO.PWM(VOLTMETER, 100)
 pwm.start(100)
 time.sleep(2)
 pwm.ChangeDutyCycle(0)
 time.sleep(2)
 
-#set volume control parameters
-VoltMeterScale=1 #adjustment factor for output voltage vs. max of voltmeter
-increment=2 #bigger increment makes the volume knob more sensitive
-initialVolume=50 #initial volume level when casting
-setVolumeInterval=300 #counter to control how frequently volume change requests are sent to google
-connectiontimeout=10
+
+##########################
+### Helper Functions
+##########################
+
+def signal_error(button):
+    """Flash the button's indicator light to signal a connection error."""
+    for _ in range(5):
+        GPIO.output(LIGHTS[button], True)
+        time.sleep(0.15)
+        GPIO.output(LIGHTS[button], False)
+        time.sleep(0.15)
+
+
+def discover_chromecast(button):
+    """
+    Attempt to discover the target Chromecast, retrying on failure.
+    Returns (cast, browser) on success, or (None, None) after all retries fail.
+    """
+    for attempt in range(1, DISCOVERY_RETRIES + 1):
+        log.info("Discovery attempt %d/%d for '%s'", attempt, DISCOVERY_RETRIES, TARGETS[button])
+        chromecasts, browser = pychromecast.get_listed_chromecasts(friendly_names=[TARGETS[button]])
+        if chromecasts:
+            return chromecasts[0], browser
+        pychromecast.discovery.stop_discovery(browser)
+        if attempt < DISCOVERY_RETRIES:
+            log.warning("Device not found, retrying in %ds...", DISCOVERY_RETRY_DELAY)
+            time.sleep(DISCOVERY_RETRY_DELAY)
+    log.error("Could not find '%s' after %d attempts", TARGETS[button], DISCOVERY_RETRIES)
+    return None, None
 
 
 ##########################
-### Function to Cast to a chromecast target and monitor until playback stops or the button is pressed again
+### Cast and Monitor
 ##########################
 
-def cast_and_monitor(
-    button, 
-    #source="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",sourceaudiotype="vide/mp4"):
-    source=audiostream,sourceaudiotype="audio/mp3"):
+def cast_and_monitor(start_button):
+    """
+    Cast audio to the target Chromecast and monitor playback.
+    Handles button-switching iteratively to avoid unbounded recursion.
+    """
+    button = start_button
 
-    #define button order
-    if button==0: fbuttons=[0,1,2]
-    if button==1: fbuttons=[1,0,2]
-    if button==2: fbuttons=[2,0,1]
-    newbutton=button
+    while True:
+        GPIO.output(LIGHTS[button], True)
+        log.info("Attempting cast to '%s'", TARGETS[button])
 
-    #Illuminate status indicator
-    GPIO.output(lights[button], True)
-    print("Attempting Cast...")
-    
-    #Open connection to chromecast device
-    chromecasts, browser = pychromecast.get_listed_chromecasts(friendly_names=[targets[button]])
-    cast = chromecasts [0]
+        cast, browser = discover_chromecast(button)
+        if cast is None:
+            signal_error(button)
+            GPIO.output(LIGHTS[button], False)
+            pwm.ChangeDutyCycle(0)
+            return
 
-    #start worker thread and wait for cast device to be ready
-    cast.wait()
-    print("Casting to "+cast.device.friendly_name)
+        mc = None
+        new_button = button
+        try:
+            cast.wait()
+            log.info("Connected to '%s'", cast.device.friendly_name)
 
-    #start media
-    mc = cast.media_controller
-    cast.set_volume(initialVolume/100)
-    mc.play_media(source,sourceaudiotype)
-    mc.block_until_active()
-    print(mc.status.player_state)
-    
-    #wait for stream start
-    time.sleep(5)
-    timeout=5
-    while mc.status.player_state!="PLAYING" and timeout<connectiontimeout:
-        time.sleep(1)
-        timeout=timeout+1
-        print(timeout)
-    print(mc.status.player_state)
- 
-    #start PWM and volume control
-    setVolumeCounter=1
-    priorVolume=initialVolume
-    counter=initialVolume
-    clkLastState=GPIO.input(clk)
-    pwm.ChangeDutyCycle(counter*VoltMeterScale)
-    
-    #Loop to control volume and monitor for button presses
-    while (mc.status.player_state=="PLAYING" or mc.status.player_state=="BUFFERING"):
-    #while GPIO.input(button)==True:
-        clkState = GPIO.input(clk)
-        dtState = GPIO.input(dt)
-        if clkState != clkLastState:
-            if dtState == clkState and counter < 100:
-                counter += increment
-            elif counter > 0:
-                counter -= increment
-            #print(counter)
-            pwm.ChangeDutyCycle(counter*VoltMeterScale)
-        setVolumeCounter=(setVolumeCounter+1)%setVolumeInterval
-        if setVolumeCounter == 0 and priorVolume!=counter:
-            #print("Set Volume")
-            cast.set_volume(counter/100)
-            priorVolume=counter
-        clkLastState = clkState
-        if (GPIO.input(buttons[0])==False or GPIO.input(buttons[1])==False or GPIO.input(buttons[2])==False):
-            if GPIO.input(buttons[fbuttons[1]])==False: newbutton=fbuttons[1]
-            if GPIO.input(buttons[fbuttons[2]])==False: newbutton=fbuttons[2]
-            break
-        time.sleep(.002)
-        #print(mc.status.player_state)
-        #print(GPIO.input(button))
+            mc = cast.media_controller
+            cast.set_volume(INITIAL_VOLUME / 100)
+            mc.play_media(AUDIO_STREAM, AUDIO_TYPE)
+            mc.block_until_active()
+            log.info("Initial player state: %s", mc.status.player_state)
 
-    #End cast, close connection, and turn off light and volume
-    print("Closing Cast Session")
-    GPIO.output(lights[button], False)
-    pwm.ChangeDutyCycle(0)
-    mc.stop()
-    time.sleep(1)
-    #print(mc.status.player_state)
-    #cast.disconnect()
-    pychromecast.discovery.stop_discovery(browser)
-    time.sleep(1)
+            # Wait for PLAYING state
+            deadline = time.time() + CONNECTION_TIMEOUT
+            while mc.status.player_state != "PLAYING" and time.time() < deadline:
+                time.sleep(1)
 
-    print(button)
-    print(newbutton)
-    if newbutton==button: return
+            if mc.status.player_state not in ("PLAYING", "BUFFERING"):
+                log.error("Stream never started. Final state: %s", mc.status.player_state)
+                signal_error(button)
+                return
 
-    print("didn't leave")
-    cast_and_monitor(newbutton)
+            log.info("Streaming: %s", mc.status.player_state)
 
+            # Volume control state
+            counter = INITIAL_VOLUME
+            prior_volume = INITIAL_VOLUME
+            clk_last_state = GPIO.input(CLK)
+            pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
+            last_volume_set = time.time()
 
-#Testing line - runs function without try to surface exceptions in testing
-#cast_and_monitor(button=0)
+            # Button priority order: pressed button first, then others in order
+            other_buttons = [i for i in range(len(BUTTONS)) if i != button]
+            priority = [button] + other_buttons
+
+            # Main playback loop
+            while mc.status.player_state in ("PLAYING", "BUFFERING"):
+                # Rotary encoder volume tracking
+                clk_state = GPIO.input(CLK)
+                dt_state  = GPIO.input(DT)
+                if clk_state != clk_last_state:
+                    if dt_state == clk_state and counter < 100:
+                        counter += INCREMENT
+                    elif counter > 0:
+                        counter -= INCREMENT
+                    pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
+                clk_last_state = clk_state
+
+                # Time-based volume updates to Chromecast
+                now = time.time()
+                if now - last_volume_set >= VOLUME_SET_INTERVAL and prior_volume != counter:
+                    cast.set_volume(counter / 100)
+                    prior_volume = counter
+                    last_volume_set = now
+
+                # Button press detection
+                pressed = [i for i in range(len(BUTTONS)) if GPIO.input(BUTTONS[i]) == False]
+                if pressed:
+                    new_button = next((b for b in priority if b in pressed), pressed[0])
+                    break
+
+                time.sleep(0.002)
+
+        except Exception as e:
+            log.error("Error during cast session: %s", e, exc_info=True)
+            signal_error(button)
+
+        finally:
+            log.info("Closing cast session for '%s'", TARGETS[button])
+            GPIO.output(LIGHTS[button], False)
+            pwm.ChangeDutyCycle(0)
+            if mc is not None:
+                try:
+                    mc.stop()
+                except Exception as e:
+                    log.warning("Error stopping media controller: %s", e)
+            time.sleep(1)
+            cast.disconnect()
+            pychromecast.discovery.stop_discovery(browser)
+            time.sleep(1)
+
+        # If the same button was pressed (or no switch), exit
+        if new_button == button:
+            return
+
+        # Switch to the new target iteratively (no recursion)
+        log.info("Switching from button %d to button %d", button, new_button)
+        button = new_button
+
 
 ##########################
-### Continuous Loop Monitoring the 3 main buttons and beginning cast when they are pressed
-#########################
-
+### Main Loop
+##########################
 
 try:
-    GPIO.output(statuslight,True)
+    GPIO.output(STATUS_LIGHT, True)
     while True:
-        if GPIO.input(buttons[0])==False:
-            GPIO.output(statuslight, False)
-            try:
-                cast_and_monitor(button=0)
-            except:
-                print("Function cast_and_monitor failed")
-                GPIO.output(lights[0], False)
-                pwm.ChangeDutyCycle(0)
-            GPIO.output(statuslight, True)
-        elif GPIO.input(buttons[1])==False:
-            GPIO.output(statuslight, False)
-            try:
-                cast_and_monitor(button=1)
-            except:
-                print("Function cast_and_monitor failed")
-                GPIO.output(lights[1], False)
-                pwm.ChangeDutyCycle(0)
-            GPIO.output(statuslight, True)
-        elif GPIO.input(buttons[2])==False:
-            GPIO.output(statuslight, False)
-            try:
-                cast_and_monitor(button=2)
-            except:
-                print("Function cast_and_monitor failed")
-                GPIO.output(lights[2], False)
-                pwm.ChangeDutyCycle(0)
-            GPIO.output(statuslight, True)
-        time.sleep(.05)
+        for i, btn in enumerate(BUTTONS):
+            if GPIO.input(btn) == False:
+                GPIO.output(STATUS_LIGHT, False)
+                try:
+                    cast_and_monitor(i)
+                except Exception as e:
+                    log.error("cast_and_monitor(%d) failed: %s", i, e, exc_info=True)
+                    GPIO.output(LIGHTS[i], False)
+                    pwm.ChangeDutyCycle(0)
+                GPIO.output(STATUS_LIGHT, True)
+                break
+        time.sleep(0.05)
 
-except:
-    print("there was an exception")
+except Exception as e:
+    log.error("Fatal error in main loop: %s", e, exc_info=True)
     pwm.ChangeDutyCycle(0)
     GPIO.cleanup()
 
 GPIO.cleanup()
-

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -145,7 +145,7 @@ def discover_chromecast(button):
         chromecasts, browser = pychromecast.get_listed_chromecasts(friendly_names=[TARGETS[button]])
         if chromecasts:
             return chromecasts[0], browser
-        pychromecast.discovery.stop_discovery(browser)
+        browser.stop_discovery()
         if attempt < DISCOVERY_RETRIES:
             log.warning("Device not found, retrying in %ds...", DISCOVERY_RETRY_DELAY)
             time.sleep(DISCOVERY_RETRY_DELAY)
@@ -253,7 +253,7 @@ def cast_and_monitor(start_button):
                     log.warning("Error stopping media controller: %s", e)
             time.sleep(1)
             cast.disconnect()
-            pychromecast.discovery.stop_discovery(browser)
+            browser.stop_discovery()
             time.sleep(1)
 
         # If the same button was pressed (or no switch), exit

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -217,10 +217,10 @@ def cast_and_monitor(start_button):
                 # Rotary encoder volume tracking
                 clk_state = GPIO.input(CLK)
                 dt_state  = GPIO.input(DT)
-                if clk_state != clk_last_state and (time.time() - last_encoder_time) > ENCODER_DEBOUNCE:
-                    if dt_state == clk_state and counter < 100:
+                if clk_state != clk_last_state and clk_state == 1 and (time.time() - last_encoder_time) > ENCODER_DEBOUNCE:
+                    if dt_state != clk_state and counter < 100:
                         counter += INCREMENT
-                    elif counter > 0:
+                    elif dt_state == clk_state and counter > 0:
                         counter -= INCREMENT
                     pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
                     last_encoder_time = time.time()

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -13,7 +13,6 @@ from config import (
     VOLT_METER_SCALE, INCREMENT, INITIAL_VOLUME,
     VOLUME_SET_INTERVAL, CONNECTION_TIMEOUT,
     DISCOVERY_RETRIES, DISCOVERY_RETRY_DELAY,
-    ENCODER_DEBOUNCE,
 )
 
 logging.basicConfig(
@@ -206,7 +205,6 @@ def cast_and_monitor(start_button):
             clk_last_state = GPIO.input(CLK)
             pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
             last_volume_set = time.time()
-            last_encoder_time = 0.0
 
             # Button priority order: pressed button first, then others in order
             other_buttons = [i for i in range(len(BUTTONS)) if i != button]
@@ -217,14 +215,12 @@ def cast_and_monitor(start_button):
                 # Rotary encoder volume tracking
                 clk_state = GPIO.input(CLK)
                 dt_state  = GPIO.input(DT)
-                if clk_state != clk_last_state and (time.time() - last_encoder_time) > ENCODER_DEBOUNCE:
-                    clockwise = (clk_state == 1 and dt_state == 0) or (clk_state == 0 and dt_state == 1)
-                    if clockwise and counter < 100:
+                if clk_state != clk_last_state:
+                    if dt_state == clk_state and counter < 100:
                         counter += INCREMENT
-                    elif not clockwise and counter > 0:
+                    elif counter > 0:
                         counter -= INCREMENT
                     pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
-                    last_encoder_time = time.time()
                 clk_last_state = clk_state
 
                 # Time-based volume updates to Chromecast

--- a/CastMyVinyl.py
+++ b/CastMyVinyl.py
@@ -13,6 +13,7 @@ from config import (
     VOLT_METER_SCALE, INCREMENT, INITIAL_VOLUME,
     VOLUME_SET_INTERVAL, CONNECTION_TIMEOUT,
     DISCOVERY_RETRIES, DISCOVERY_RETRY_DELAY,
+    ENCODER_DEBOUNCE,
 )
 
 logging.basicConfig(
@@ -205,6 +206,7 @@ def cast_and_monitor(start_button):
             clk_last_state = GPIO.input(CLK)
             pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
             last_volume_set = time.time()
+            last_encoder_time = 0.0
 
             # Button priority order: pressed button first, then others in order
             other_buttons = [i for i in range(len(BUTTONS)) if i != button]
@@ -215,12 +217,13 @@ def cast_and_monitor(start_button):
                 # Rotary encoder volume tracking
                 clk_state = GPIO.input(CLK)
                 dt_state  = GPIO.input(DT)
-                if clk_state != clk_last_state:
+                if clk_state != clk_last_state and (time.time() - last_encoder_time) > ENCODER_DEBOUNCE:
                     if dt_state == clk_state and counter < 100:
                         counter += INCREMENT
                     elif counter > 0:
                         counter -= INCREMENT
                     pwm.ChangeDutyCycle(counter * VOLT_METER_SCALE)
+                    last_encoder_time = time.time()
                 clk_last_state = clk_state
 
                 # Time-based volume updates to Chromecast

--- a/config.py
+++ b/config.py
@@ -4,7 +4,7 @@
 # =============================================================================
 
 # Audio stream URL (Raspberry Pi local stream server)
-AUDIO_STREAM = "http://192.168.86.32:8000/mystream.mp3"
+AUDIO_STREAM = "http://192.168.68.52:8000/mystream.mp3"
 AUDIO_TYPE = "audio/mp3"
 
 # Chromecast target friendly names — index must match BUTTONS and LIGHTS below

--- a/config.py
+++ b/config.py
@@ -1,0 +1,30 @@
+# =============================================================================
+# CastMyVinyl Configuration
+# Edit this file to adapt to your network/hardware without touching core logic.
+# =============================================================================
+
+# Audio stream URL (Raspberry Pi local stream server)
+AUDIO_STREAM = "http://192.168.86.32:8000/mystream.mp3"
+AUDIO_TYPE = "audio/mp3"
+
+# Chromecast target friendly names — index must match BUTTONS and LIGHTS below
+TARGETS = ["Downstairs Speakers", "Upstairs Speakers", "All Devices"]
+
+# GPIO pin mapping (BCM numbering) — DO NOT CHANGE, pins are hardwired
+BUTTONS      = [22, 27, 17]   # tactile push buttons (active low)
+LIGHTS       = [25, 24, 23]   # indicator LEDs per button
+STATUS_LIGHT = 16             # global status LED
+CLK          = 19             # rotary encoder clock
+DT           = 26             # rotary encoder data
+VOLTMETER    = 21             # PWM-driven analog voltmeter needle
+
+# Volume control
+VOLT_METER_SCALE   = 1     # output duty cycle multiplier vs. counter value
+INCREMENT          = 2     # encoder steps per volume unit
+INITIAL_VOLUME     = 50   # volume (0–100) applied when casting starts
+VOLUME_SET_INTERVAL = 0.3  # seconds between volume updates sent to Chromecast
+
+# Connectivity
+CONNECTION_TIMEOUT    = 10  # seconds to wait for PLAYING state before giving up
+DISCOVERY_RETRIES     = 5   # number of Chromecast discovery attempts before failing
+DISCOVERY_RETRY_DELAY = 3   # seconds between discovery retries

--- a/config.py
+++ b/config.py
@@ -19,10 +19,11 @@ DT           = 26             # rotary encoder data
 VOLTMETER    = 21             # PWM-driven analog voltmeter needle
 
 # Volume control
-VOLT_METER_SCALE   = 1     # output duty cycle multiplier vs. counter value
-INCREMENT          = 2     # encoder steps per volume unit
-INITIAL_VOLUME     = 50   # volume (0–100) applied when casting starts
-VOLUME_SET_INTERVAL = 0.3  # seconds between volume updates sent to Chromecast
+VOLT_METER_SCALE    = 1     # output duty cycle multiplier vs. counter value
+INCREMENT           = 2     # encoder steps per volume unit
+INITIAL_VOLUME      = 50    # volume (0–100) applied when casting starts
+VOLUME_SET_INTERVAL = 0.3   # seconds between volume updates sent to Chromecast
+ENCODER_DEBOUNCE    = 0.005 # seconds to ignore further encoder transitions after a change (reduces bounce noise)
 
 # Connectivity
 CONNECTION_TIMEOUT    = 10  # seconds to wait for PLAYING state before giving up

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ AUDIO_TYPE = "audio/mp3"
 # Chromecast target friendly names — index must match BUTTONS and LIGHTS below
 TARGETS = ["Vinyl Local", "Vinyl Remote", "Vinyl All"]
 
-# GPIO pin mapping (BCM numbering) — DO NOT CHANGE, pins are hardwired
+# GPIO pin mapping (BCM numbering) — update if wiring changes
 BUTTONS      = [22, 27, 17]   # tactile push buttons (active low)
 LIGHTS       = [25, 24, 23]   # indicator LEDs per button
 STATUS_LIGHT = 16             # global status LED
@@ -23,7 +23,6 @@ VOLT_METER_SCALE    = 1     # output duty cycle multiplier vs. counter value
 INCREMENT           = 2     # encoder steps per volume unit
 INITIAL_VOLUME      = 50    # volume (0–100) applied when casting starts
 VOLUME_SET_INTERVAL = 0.3   # seconds between volume updates sent to Chromecast
-ENCODER_DEBOUNCE    = 0.005 # seconds to ignore further encoder transitions after a change (reduces bounce noise)
 
 # Connectivity
 CONNECTION_TIMEOUT    = 10  # seconds to wait for PLAYING state before giving up

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ AUDIO_STREAM = "http://192.168.86.32:8000/mystream.mp3"
 AUDIO_TYPE = "audio/mp3"
 
 # Chromecast target friendly names — index must match BUTTONS and LIGHTS below
-TARGETS = ["Downstairs Speakers", "Upstairs Speakers", "All Devices"]
+TARGETS = ["Vinyl Local", "Vinyl Remote", "Vinyl All"]
 
 # GPIO pin mapping (BCM numbering) — DO NOT CHANGE, pins are hardwired
 BUTTONS      = [22, 27, 17]   # tactile push buttons (active low)

--- a/config.py
+++ b/config.py
@@ -15,7 +15,7 @@ BUTTONS      = [22, 27, 17]   # tactile push buttons (active low)
 LIGHTS       = [25, 24, 23]   # indicator LEDs per button
 STATUS_LIGHT = 16             # global status LED
 CLK          = 19             # rotary encoder clock
-DT           = 26             # rotary encoder data
+DT           = 12             # rotary encoder data
 VOLTMETER    = 21             # PWM-driven analog voltmeter needle
 
 # Volume control

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-python3 /home/pi/Desktop/castmyvinyl/CastMyVinyl.py > /home/pi/Desktop/castmyvinyl/CMVlog.txt
+python3 /home/pi/Desktop/castmyvinyl/CastMyVinyl.py

--- a/test_cc.py
+++ b/test_cc.py
@@ -33,4 +33,4 @@ while mc.status.player_state == "PLAYING":
 
 print(mc.status.player_state)
 
-pychromecast.discovery.stop_discovery(browser)
+browser.stop_discovery()

--- a/test_cc.py
+++ b/test_cc.py
@@ -1,29 +1,21 @@
 import sys
 import time
-import pychromecast 
+import pychromecast
 
-# Define Chromecasts we're searching for
-target_chromecasts=["Living Room Speaker","Kitchen display","Office Speaker"]
+from config import AUDIO_STREAM, AUDIO_TYPE, TARGETS
+
+# Select which Chromecast to test (0=Downstairs, 1=Upstairs, 2=All Devices)
 target = 2
 
-# List chromecasts on the network, but don't connect
-#services, browser = pychromecast.discovery.discover_chromecasts()
-# Shut down discovery
-#pychromecast.discovery.stop_discovery(browser)
-
-# Discover and connect to chromecasts in target list
-chromecasts, browser = pychromecast.get_listed_chromecasts(friendly_names=[target_chromecasts[target]])
-
+chromecasts, browser = pychromecast.get_listed_chromecasts(friendly_names=[TARGETS[target]])
 cast = chromecasts[0]
-# Start worker thread and wait for cast device to be ready
+
 cast.wait()
 print(cast.device.friendly_name)
-print("Volume = "+str(cast.status.volume_level))
-#print("")
+print("Volume = " + str(cast.status.volume_level))
 
 mc = cast.media_controller
-mc.play_media('http://192.168.86.41:8000/rapi.mp3','audio/mp3')
-#mc.play_media('http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4', 'video/mp4')
+mc.play_media(AUDIO_STREAM, AUDIO_TYPE)
 mc.block_until_active()
 print(mc.status.player_state)
 
@@ -35,13 +27,10 @@ mc.play()
 time.sleep(10)
 print("Initialized! " + mc.status.player_state)
 
-while mc.status.player_state=="PLAYING":
-	time.sleep(5)
-	print(mc.status.player_state)
+while mc.status.player_state == "PLAYING":
+    time.sleep(5)
+    print(mc.status.player_state)
 
-#mc.stop()
 print(mc.status.player_state)
 
-# Shut down discovery
 pychromecast.discovery.stop_discovery(browser)
-

--- a/test_encoder.py
+++ b/test_encoder.py
@@ -1,0 +1,13 @@
+import RPi.GPIO as GPIO
+import time
+
+GPIO.setmode(GPIO.BCM)
+GPIO.setup(19, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+GPIO.setup(26, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+
+try:
+    while True:
+        print('CLK(19)=%d  DT(26)=%d' % (GPIO.input(19), GPIO.input(26)))
+        time.sleep(0.05)
+except KeyboardInterrupt:
+    GPIO.cleanup()

--- a/test_encoder.py
+++ b/test_encoder.py
@@ -3,11 +3,11 @@ import time
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(19, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
-GPIO.setup(26, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+GPIO.setup(12, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
 
 try:
     while True:
-        print('CLK(19)=%d  DT(26)=%d' % (GPIO.input(19), GPIO.input(26)))
+        print('CLK(19)=%d  DT(12)=%d' % (GPIO.input(19), GPIO.input(12)))
         time.sleep(0.05)
 except KeyboardInterrupt:
     GPIO.cleanup()

--- a/test_encoder.py
+++ b/test_encoder.py
@@ -3,7 +3,7 @@ import time
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(19, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
-GPIO.setup(26, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+GPIO.setup(26, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
 
 try:
     while True:

--- a/test_encoder.py
+++ b/test_encoder.py
@@ -3,7 +3,7 @@ import time
 
 GPIO.setmode(GPIO.BCM)
 GPIO.setup(19, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
-GPIO.setup(26, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+GPIO.setup(26, GPIO.IN, pull_up_down=GPIO.PUD_UP)
 
 try:
     while True:

--- a/test_gpio.py
+++ b/test_gpio.py
@@ -1,0 +1,28 @@
+import RPi.GPIO as GPIO
+import time
+import os
+
+# All BCM GPIO pins available on the Pi
+PINS = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+        19, 20, 21, 22, 23, 24, 25, 26, 27]
+
+GPIO.setmode(GPIO.BCM)
+GPIO.setwarnings(False)
+
+for pin in PINS:
+    GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+
+prev = {}
+
+try:
+    print("Monitoring all GPIO pins. Turn the knob, press buttons, etc.")
+    print("Only changes are printed. Ctrl+C to exit.\n")
+    while True:
+        current = {pin: GPIO.input(pin) for pin in PINS}
+        for pin, val in current.items():
+            if val != prev.get(pin):
+                print("GPIO %2d changed: %d -> %d" % (pin, prev.get(pin, -1), val))
+        prev = current
+        time.sleep(0.005)
+except KeyboardInterrupt:
+    GPIO.cleanup()


### PR DESCRIPTION
## Summary
- Fixed DT pin misconfiguration: was set to GPIO 26, actually wired to GPIO 12
- Removed encoder pin-state debug logging (volume-set log retained)
- Updated `test_encoder.py` to use consistent PUD_DOWN on both CLK and DT
- Cleaned up config: updated misleading comment, removed unused `ENCODER_DEBOUNCE`

## Test plan
- [x] GPIO monitor confirmed DT signal on GPIO 12
- [x] Encoder test confirmed both CLK and DT responding correctly
- [x] Volume control working end-to-end
- [x] Chromecast disconnect/recovery tested (case 10)
- [x] Happy path casting to all speaker groups verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)